### PR TITLE
Specify workspace path for Vue Frontend entry

### DIFF
--- a/linky-link.code-workspace
+++ b/linky-link.code-workspace
@@ -1,9 +1,10 @@
 {
   "folders": [
     {
-      "path": "Vue.js Frontend"
-    },
-    {
+      "name": "Vue.js Frontend",
+      "path": "frontend"
+      },
+          {
       "name": "Serverless Backend",
       "path": "backend/src/LinkyLink"
     },


### PR DESCRIPTION
The name of the workspace entry name was marked as the path.  Changed to be identified as name, and added the path to be frontend folder.